### PR TITLE
Add a service role for agents

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,12 +51,12 @@ resource "google_project_iam_custom_role" "mcd_agent_storage_role" {
 }
 
 resource "google_project_iam_custom_role" "mcd_agent_service_role" {
-  count   = var.remote_upgradable ? 0 : 1
   role_id = "mcdAgentServiceRole${random_id.mcd_agent_id.hex}"
   title   = "MCD Agent Service Role"
-  permissions = [
-    "run.services.get"
-  ]
+  permissions = compact([
+    "run.services.get",
+    var.remote_upgradable ? "run.services.update" : null
+  ])
   project = var.project_id
 }
 
@@ -99,7 +99,7 @@ resource "google_cloud_run_service_iam_binding" "mcd_agent_service_sa_binding" {
   location = var.location
   project  = var.project_id
   service  = var.remote_upgradable ? google_cloud_run_v2_service.mcd_agent_service_with_remote_upgrade_support[0].name : google_cloud_run_v2_service.mcd_agent_service[0].name
-  role     = var.remote_upgradable ? "roles/run.developer" : "projects/${var.project_id}/roles/${google_project_iam_custom_role.mcd_agent_service_role[0].role_id}"
+  role     = "projects/${var.project_id}/roles/${google_project_iam_custom_role.mcd_agent_service_role.role_id}"
   members = [
     "serviceAccount:${google_service_account.mcd_agent_service_sa.email}",
   ]


### PR DESCRIPTION
This change:

- Uses more minimal permissions for upgrades and adds a permission to retrieve the image tag for agents without remote upgrade support