### PR TITLE
Added the required permission to retrieve CloudRun logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,7 @@ resource "google_project_iam_custom_role" "mcd_agent_project_role" {
   title   = "MCD Agent Project Role"
   permissions = compact([
     "iam.serviceAccounts.signBlob",
+    "logging.logEntries.list",
     var.remote_upgradable ? "iam.serviceAccounts.actAs" : null,
     var.remote_upgradable ? "run.operations.get" : null
   ])


### PR DESCRIPTION
In order to implement a new endpoint to return CloudRun service logs, we need the following permission at the project level: `logging.logEntries.list`